### PR TITLE
fixed iOS warning

### DIFF
--- a/ios/RNPhotoEditorSDK.m
+++ b/ios/RNPhotoEditorSDK.m
@@ -123,7 +123,7 @@ RCT_EXPORT_METHOD(present:(nullable NSURLRequest *)request
     PESDKPhoto *photo = [[PESDKPhoto alloc] initWithURL:request.URL];
     [self present:photo withConfiguration:configuration andSerialization:state resolve:resolve reject:reject];
   } else {
-    [self.bridge.imageLoader loadImageWithURLRequest:request callback:^(NSError *error, UIImage *image) {
+    [[self.bridge moduleForName:@"ImageLoader" lazilyLoadIfNecessary:YES] loadImageWithURLRequest:request callback:^(NSError *error, UIImage *image) {
       if (error) {
         reject(RN_IMGLY.kErrorUnableToLoad, [NSString RN_IMGLY_string:@"Unable to load image." withError:error], error);
         return;


### PR DESCRIPTION
The following warnings were generated in the iOS simulator. Because of this, the editor could not be opened on the real iPhone. This was resolved.

`Calling bridge.imageLoader is deprecated and will not work in newer versions of RN. Please update to the moduleForClass API or Please update to the moduleForClass API or turboModuleLookupDelegate API.`