### PR TITLE
Update `openEditor` signature as it will return null on cancellation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -36,7 +36,7 @@ declare class PESDK {
     image: string | {uri: string} | number,
     configuration?: Configuration,
     serialization?: object
-  ): Promise<PhotoEditorResult>
+  ): Promise<PhotoEditorResult | null>
 
   /**
    * Unlock PhotoEditor SDK with a license.


### PR DESCRIPTION
TypeScript signature was incorrect on `openEditor` as it will return `null` if the user cancels.